### PR TITLE
fix package exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/types/directives/uid.d.ts",
       "import": "./dist/uid.mjs",
-      "require": "./dist/uid.umd.js",
-      "types": "./dist/types/directives/uid.d.ts"
+      "require": "./dist/uid.umd.js"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
"types" field must occur first in the exports map, otherwise there are issues when importing with `moduleResolution` set to `NodeNext`: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing